### PR TITLE
Add GitHub Actions to merge automatically

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,18 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, edited]
+    paths-ignore:
+    - '!20*/*.md'
+
+jobs:
+  auto_merge:
+    runs-on: ubuntu-latest
+    if: "! contains(github.event.pull_request.title, 'wip')"
+    steps:
+      - uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{github.token}}
+          script: |
+            github.pulls.merge(context.issue)


### PR DESCRIPTION
開発合宿のやることリストを GitHub Actions を使って自動的にマージします。

## paths-ignore 

プルリクで変更したファイルが `20*/*.md` のときだけ自動マージするようにしてあります。
books/ などの変更は自動マージされると困ると思うので。

`paths` というオプションもあるけど、この指定だと「 `20*/*.md` を1つでも含むと自動マージ」になってしまうため、 `paths-ignore` を使っています。

## 実際の運用の流れ

プルリクに `wip` か `WIP` が含まれていればマージされないようにしてあります。

1. 開発合宿の初日に `wip` をつけてプルリクをつける
2. 開発合宿の最終日に `wip` を外す
3. GitHub Actions で自動マージ

という運用になれば良さそうかなーと。

## 参考URL

- https://help.github.com/ja/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions